### PR TITLE
Split admin dashboard into subpages

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,6 +1,8 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Login from "../ui/pages/Login";
 import AdminDashboard from "../ui/pages/AdminDashboard";
+import AdminTablePage from "../ui/pages/AdminTablePage";
+import AdminProfilePage from "../ui/pages/AdminProfilePage";
 import AgentDashboard from "../ui/pages/AgentDashboard";
 import { ProtectedRoute } from "./routeGuards";
 
@@ -11,13 +13,17 @@ export default function AppRoutes() {
                 <Route path="/" element={<Login />} />
 
                 <Route
-                    path="/admin"
+                    path="/admin/*"
                     element={
                         <ProtectedRoute allowedRoles={["admin"]}>
                             <AdminDashboard />
                         </ProtectedRoute>
                     }
-                />
+                >
+                    <Route index element={<Navigate to="table" replace />} />
+                    <Route path="table" element={<AdminTablePage />} />
+                    <Route path="profile" element={<AdminProfilePage />} />
+                </Route>
 
                 <Route
                     path="/agent"

--- a/src/ui/pages/AdminDashboard.tsx
+++ b/src/ui/pages/AdminDashboard.tsx
@@ -1,15 +1,21 @@
 import { useEffect, useState } from "react";
+import { Link, Outlet } from "react-router-dom";
 import { getAllAgents } from "../../infrastructure/supabaseAgentRepository";
 import { getHeuresBetween } from "../../infrastructure/supabaseHeureRepository";
 import type { Agent } from "../../domain/models/Agent";
 import type { Heure } from "../../domain/models/Heure";
-import AdminWeekTable from "../components/AdminWeekTable";
 import LogoutButton from "../components/LogoutButton";
-import EditableWeekHoursTable from "../components/EditableWeekHoursTable";
-import IbanForm from "../components/IbanForm";
 import { supabase } from "../../lib/supabaseClient";
 import { WeekSelector } from "../components/WeekSelector";
 import {getWeekRangeFromSaturday, formatWeekRangeFromSaturday, getSaturday} from "../../shared/weekUtils";
+
+export type AdminDashboardContext = {
+    agents: Agent[];
+    heures: Heure[];
+    startDate: Date;
+    currentUserId: string | null;
+    reload: (start: Date) => Promise<void>;
+};
 
 export default function AdminDashboard() {
     const [agents, setAgents] = useState<Agent[]>([]);
@@ -53,18 +59,12 @@ export default function AdminDashboard() {
                 </div>
             </div>
 
-            <AdminWeekTable startDate={startDate} agents={agents} heures={heures} onReload={() => reload(startDate)} />
+            <nav className="mb-4 flex gap-2">
+                <Link to="table" className="btn btn-sm btn-secondary">Tableau</Link>
+                <Link to="profile" className="btn btn-sm btn-secondary">Ma fiche</Link>
+            </nav>
 
-            <div className="mb-8">
-                <h2 className="text-lg font-bold mb-2">Ma fiche personnelle</h2>
-                <IbanForm />
-                <EditableWeekHoursTable
-                    agentId={currentUserId}
-                    heures={heures.filter((h) => h.agent_id === currentUserId)}
-                    onReload={() => reload(startDate)}
-                    startDate={startDate}
-                />
-            </div>
+            <Outlet context={{ agents, heures, startDate, currentUserId, reload }} />
         </div>
     );
 }

--- a/src/ui/pages/AdminProfilePage.tsx
+++ b/src/ui/pages/AdminProfilePage.tsx
@@ -1,0 +1,24 @@
+import IbanForm from "../components/IbanForm";
+import EditableWeekHoursTable from "../components/EditableWeekHoursTable";
+import { useOutletContext } from "react-router-dom";
+import type { AdminDashboardContext } from "./AdminDashboard";
+
+export default function AdminProfilePage() {
+    const { heures, startDate, reload, currentUserId } = useOutletContext<AdminDashboardContext>();
+
+    if (!currentUserId) return null;
+    const myHeures = heures.filter((h) => h.agent_id === currentUserId);
+
+    return (
+        <div className="mb-8 space-y-4">
+            <h2 className="text-lg font-bold">Ma fiche personnelle</h2>
+            <IbanForm />
+            <EditableWeekHoursTable
+                agentId={currentUserId}
+                heures={myHeures}
+                onReload={() => reload(startDate)}
+                startDate={startDate}
+            />
+        </div>
+    );
+}

--- a/src/ui/pages/AdminTablePage.tsx
+++ b/src/ui/pages/AdminTablePage.tsx
@@ -1,0 +1,15 @@
+import AdminWeekTable from "../components/AdminWeekTable";
+import { useOutletContext } from "react-router-dom";
+import type { AdminDashboardContext } from "./AdminDashboard";
+
+export default function AdminTablePage() {
+    const { agents, heures, startDate, reload } = useOutletContext<AdminDashboardContext>();
+    return (
+        <AdminWeekTable
+            startDate={startDate}
+            agents={agents}
+            heures={heures}
+            onReload={() => reload(startDate)}
+        />
+    );
+}


### PR DESCRIPTION
## Summary
- add AdminProfilePage and AdminTablePage
- update AdminDashboard to provide navigation and outlet
- configure nested admin routes

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889d847705c8320b96d5442fb1824e9