### PR TITLE
fix : create user

### DIFF
--- a/src/infrastructure/supabaseAgentRepository.ts
+++ b/src/infrastructure/supabaseAgentRepository.ts
@@ -9,7 +9,7 @@ export const getAllAgents = async (): Promise<Agent[]> => {
 
 export const createAgent = async (agent: CreateAgent): Promise<void> => {
     const { data, error } = await supabase.auth.signUp({
-        email: agent.pseudo,
+        email: `${agent.pseudo}@lssd.local`,
         password: agent.password, // Assuming matricule is used as password
     });
 


### PR DESCRIPTION
This pull request updates the agent creation logic to use a standardized email format when registering new agents. Instead of using the agent's pseudo directly as the email, it now appends the domain `@lssd.local` to ensure all agent emails follow a consistent pattern.

* Agent creation: Changed the email field in the `createAgent` function to use `${agent.pseudo}@lssd.local` instead of just `agent.pseudo`, enforcing a uniform email format for new agents.